### PR TITLE
Persist assets data across refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@ function parseCSV(text){
     Account: (r.Account||'').trim()
   })).filter(r=>r.Date);
   buildIndexes();
+  localStorage.setItem('assetManagerData', JSON.stringify(RAW));
   onDataReady();
   $("exportCsv").disabled = RAW.length===0;
 }
@@ -421,6 +422,21 @@ function onDataReady(){
   buildHeat();
   runCompare();
 }
+
+function loadSaved(){
+  const saved = localStorage.getItem('assetManagerData');
+  if(!saved) return;
+  try{
+    RAW = JSON.parse(saved);
+    buildIndexes();
+    onDataReady();
+    $("exportCsv").disabled = RAW.length===0;
+  }catch(e){
+    console.error('failed to load saved data', e);
+  }
+}
+
+loadSaved();
 
 $("file").addEventListener('change', e=>{
   const file = e.target.files[0];


### PR DESCRIPTION
## Summary
- persist parsed CSV data to localStorage
- load persisted data on startup so assets remain after refresh

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68970fe96c2883289a1251c794c38348