### PR TITLE
Fix daily trend chart rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@ function drawStack(){
     type:'line',
     data:{ labels, datasets },
     options:{
-      responsive:true, maintainAspectRatio:false, parsing:false,
+      responsive:true, maintainAspectRatio:false,
       animation:{duration:500}, interaction:{ mode:'index', intersect:false },
       scales:{
         y:{ ticks:{ callback:(v)=> yen(v)+'円', color:'#e8ecf1' }, grid:{ color:'rgba(255,255,255,0.12)' } },


### PR DESCRIPTION
## Summary
- fix daily trend chart by letting Chart.js parse datasets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68972d78c7288328aa0b4552738b9c32