### PR TITLE
Fix daily trend chart display

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@ function drawStack(){
     type:'line',
     data:{labels,datasets},
     options:{
-      responsive:true, maintainAspectRatio:false, parsing:false,
+      responsive:true, maintainAspectRatio:false,
       interaction:{mode:'index',intersect:false},
       elements:{point:{radius:0,hoverRadius:0}, line:{tension:0.35}},
       scales:{


### PR DESCRIPTION
## Summary
- allow Chart.js to parse daily trend data so the day-by-day transition is rendered

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68972faab2308328b90a3af904d7475a