### PR TITLE
Simplify stack view legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,11 +264,26 @@ function drawStack(){
   if(stackChart) stackChart.destroy();
   stackChart = new Chart($("stackChart"), {
     type:'bar',
-    data:{ labels, datasets: cats.map((c,i)=>({label:c, data:series[i], stack:'s'})) },
+    data:{
+      labels,
+      datasets: cats.map((c,i) => ({
+        label:c,
+        data:series[i],
+        stack:'s',
+        backgroundColor:'#3d8ed6'
+      }))
+    },
     options:{
       responsive:true,
       scales:{ x:{ stacked:true }, y:{ stacked:true, ticks:{ callback:(v)=> '¥'+new Intl.NumberFormat('ja-JP').format(v) } } },
-      plugins:{ legend:{ position:'bottom' } }
+      plugins:{
+        legend:{
+          position:'bottom',
+          labels:{
+            filter:item=>item.text.toLowerCase()==='stock'
+          }
+        }
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary
- Unify stacked bar colors in the transition view
- Show only the `stock` item in the stack legend

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973386e9a483289baa71d27c874e2a