### PR TITLE
Fix calendar cell overflow on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,9 +55,9 @@
     .day-cell.disabled{opacity:.35;cursor:default}
     .day-cell:hover{border-color:#3b4252}
     .day-head{display:flex;justify-content:space-between;align-items:center;gap:6px}
-    .day-num{font-size:12px;color:#c9ced6;flex:0 0 auto}
-    .day-total{font-size:12px;color:#c9d7ff;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    .day-delta{font-size:11px}
+    .day-num{font-size:12px;line-height:1;color:#c9ced6;flex:0 0 auto}
+    .day-total{font-size:12px;line-height:1;color:#c9d7ff;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .day-delta{font-size:11px;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .selected{outline:2px solid var(--accent); outline-offset:-2px}
     .cal-detail{margin-top:12px;background:#1b1b1b;border:1px solid var(--line);border-radius:12px;padding:14px}
     .detail-title{font-size:16px;font-weight:600;margin:0 0 8px 0}
@@ -77,6 +77,8 @@
       .weekday{font-size:11px}
       .cal-title{font-size:16px}
       .kpi{grid-template-columns:1fr}
+      .day-total{font-size:10px}
+      .day-delta{font-size:9px}
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- Prevent long day deltas from expanding calendar cells
- Shrink day text on mobile so cells remain square

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689757bc09308328b4355176130a836c