### PR TITLE
fix per-stock delta calculation in calendar detail

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,11 +475,9 @@ function renderCalendarDetail(){
     .filter(r => r.Amount !== 0)
     .sort((a,b)=>a.Name.localeCompare(b.Name));
   const detailLines = rows.map(r=>{
-    let prevAmt = null;
-    for(let i=idx-1; i>=0 && prevAmt===null; i--){
-      const pr = (byDate.get(DATES[i])||[]).find(x=>x.Name===r.Name);
-      if(pr) prevAmt = pr.Amount;
-    }
+    const prevAmt = prev
+      ? ((byDate.get(prev) || []).find(x=>x.Name === r.Name)?.Amount || 0)
+      : null;
     const diff = prevAmt===null ? null : r.Amount - prevAmt;
     const diffStr = diff===null ? '—' : ((diff>=0?'+':'')+yen(diff));
     const diffColor = diff===null ? 'var(--muted)' : (diff>=0 ? '#22c55e' : '#ef4444');


### PR DESCRIPTION
## Summary
- adjust calendar detail stock delta to compare against previous date rather than last entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68975cb9f9d48328b18acdf59f677cdc