### PR TITLE
Improve mobile layout for 2-day comparison table

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,9 @@
       .kpi{grid-template-columns:1fr}
       .day-total{font-size:9px}  /* ← さらに小さく */
       .day-delta{font-size:9px}
-      #cmpTable{min-width:100%}
+      #cmpTable{min-width:100%;font-size:11px}
+      #cmpTable th,#cmpTable td{padding:4px 3px}
+      #cmpTable th:first-child,#cmpTable td:first-child{white-space:normal;word-break:break-word}
       .year-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
     }
     @media (max-width:420px){


### PR DESCRIPTION
## Summary
- Adjust comparison table styles for small screens
- Reduce font size and padding and allow wrapping of stock names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689783f81e048328b613de51563c52f4