### PR TITLE
fix pie chart rendering as semi circle

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,8 +439,7 @@ function drawPie(){
             return `${ctx.label}: ${yen(val)} (${pct.toFixed(1)}%)`;
           }
         }}
-      },
-      rotation:-90, circumference:180 // 半円が良ければ有効化、円で良ければ削除
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- remove rotation/circumference limits so asset classification chart renders as full circle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689806523d9083288ae4387030f8429a