### PR TITLE
feat: add cyberpunk themed colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,22 +79,22 @@
     .mini-day{
       width:100%;aspect-ratio:1/1;border:none;border-radius:2px;
       display:flex;align-items:center;justify-content:center;
-      color:#fff;background:rgba(0,0,0,0.6);transition:background-color .2s;
+      color:#fff;background:rgba(0,0,0,0.3);transition:background-color .2s;
     }
-    .mini-day.neutral{background:rgba(0,0,0,0.6)}
-    .mini-day.gain-low{background:rgba(0,255,0,0.3)}
-    .mini-day.gain-mid{background:rgba(0,255,0,0.6)}
-    .mini-day.gain-high{background:rgba(0,255,0,0.8)}
-    .mini-day.loss-low{background:rgba(255,0,0,0.3);color:#eee}
-    .mini-day.loss-mid{background:rgba(255,0,0,0.6);color:#eee}
-    .mini-day.loss-high{background:rgba(255,0,0,0.8);color:#eee}
-    .mini-day.gain-low:hover{background:rgba(0,255,0,0.5)}
-    .mini-day.gain-mid:hover{background:rgba(0,255,0,0.8)}
-    .mini-day.gain-high:hover{background:rgba(0,255,0,1)}
-    .mini-day.loss-low:hover{background:rgba(255,0,0,0.5)}
-    .mini-day.loss-mid:hover{background:rgba(255,0,0,0.8)}
-    .mini-day.loss-high:hover{background:rgba(255,0,0,1)}
-    .mini-day.neutral:hover{background:rgba(0,0,0,0.8)}
+    .mini-day.neutral{background:rgba(0,0,0,0.3)}
+    .mini-day.gain-low{background:rgba(34,197,94,0.25)}
+    .mini-day.gain-mid{background:rgba(34,197,94,0.45)}
+    .mini-day.gain-high{background:rgba(34,197,94,0.65)}
+    .mini-day.loss-low{background:rgba(239,68,68,0.25);color:#eee}
+    .mini-day.loss-mid{background:rgba(239,68,68,0.45);color:#eee}
+    .mini-day.loss-high{background:rgba(239,68,68,0.65);color:#eee}
+    .mini-day.gain-low:hover{background:rgba(34,197,94,0.35)}
+    .mini-day.gain-mid:hover{background:rgba(34,197,94,0.6)}
+    .mini-day.gain-high:hover{background:rgba(34,197,94,0.8)}
+    .mini-day.loss-low:hover{background:rgba(239,68,68,0.35)}
+    .mini-day.loss-mid:hover{background:rgba(239,68,68,0.6)}
+    .mini-day.loss-high:hover{background:rgba(239,68,68,0.8)}
+    .mini-day.neutral:hover{background:rgba(0,0,0,0.5)}
     .pos{color:#22c55e}.neg{color:#ef4444}
 
     /* tables */
@@ -324,29 +324,27 @@ const META_BY_DATE_NAME = new Map(); // date -> Map(Name -> {AssetClass,...})
 const $ = id => document.getElementById(id);
 const yen = n => '¥' + new Intl.NumberFormat('ja-JP').format(Math.round(n ?? 0));
 const fmt = n => new Intl.NumberFormat('ja-JP').format(Math.round(n ?? 0));
-const COLORS = ['#3b82f6','#f59e0b','#10b981','#ef4444','#8b5cf6','#14b8a6','#eab308','#ec4899','#6366f1','#06b6d4'];
+const COLORS = [
+  'rgba(255,0,255,0.8)','rgba(0,255,255,0.8)','rgba(255,255,0,0.8)','rgba(0,255,170,0.8)','rgba(255,0,170,0.8)',
+  'rgba(0,170,255,0.8)','rgba(170,0,255,0.8)','rgba(255,85,0,0.8)','rgba(0,255,85,0.8)','rgba(85,0,255,0.8)'
+];
 
-function hsl(h, s, l, a=1){
-  return `hsla(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%, ${a})`;
-}
-function getPalette(n, baseHue=210, s=62, l=52, alpha=0.95){
-  const phi = 137.508; // 黄金角
+function getPalette(n){
+  const base = [
+    'rgba(255,0,255,0.7)','rgba(0,255,255,0.7)','rgba(255,255,0,0.7)','rgba(0,255,170,0.7)','rgba(255,0,170,0.7)',
+    'rgba(0,170,255,0.7)','rgba(170,0,255,0.7)','rgba(255,85,0,0.7)','rgba(0,255,85,0.7)','rgba(85,0,255,0.7)'
+  ];
   const arr = [];
-  for(let i=0;i<n;i++){
-    const hue = (baseHue + i*phi) % 360;
-    const li  = l + (i%2===0 ? -6 : 6); // 交互に明度を少し振る
-    arr.push(hsl(hue, s, li, alpha));
-  }
+  for(let i=0;i<n;i++) arr.push(base[i%base.length]);
   return arr;
 }
-function getHoverPalette(n, baseHue=210, s=62, l=52, alpha=1){
-  const phi = 137.508;
+function getHoverPalette(n){
+  const base = [
+    'rgba(255,0,255,0.9)','rgba(0,255,255,0.9)','rgba(255,255,0,0.9)','rgba(0,255,170,0.9)','rgba(255,0,170,0.9)',
+    'rgba(0,170,255,0.9)','rgba(170,0,255,0.9)','rgba(255,85,0,0.9)','rgba(0,255,85,0.9)','rgba(85,0,255,0.9)'
+  ];
   const arr = [];
-  for(let i=0;i<n;i++){
-    const hue = (baseHue + i*phi) % 360;
-    const li  = Math.min(95, l + 8 + (i%2===0 ? -4 : 4));
-    arr.push(hsl(hue, s, li, alpha));
-  }
+  for(let i=0;i<n;i++) arr.push(base[i%base.length]);
   return arr;
 }
 


### PR DESCRIPTION
## Summary
- soften day-tile colors in yearly calendar view to match monthly transparency
- refresh palette and legend colors with a semi-transparent cyberpunk style

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689816a4b100832887c8bf71d4c37ccd