### PR TITLE
Update chart colors for asset classification and daily trends

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,16 +325,17 @@ const $ = id => document.getElementById(id);
 const yen = n => '¥' + new Intl.NumberFormat('ja-JP').format(Math.round(n ?? 0));
 const fmt = n => new Intl.NumberFormat('ja-JP').format(Math.round(n ?? 0));
 const PALETTE_BASE = [
-  '249,168,212', // pink
-  '251,146,60',  // orange
-  '96,165,250',  // blue
-  '167,139,250', // purple
-  '74,222,128',  // green
-  '248,113,113', // red
-  '250,204,21',  // yellow
-  '153,246,228', // teal
-  '196,181,253', // violet
-  '125,211,252'  // sky
+  '30,30,30',   // dark1
+  '37,37,38',   // dark2
+  '212,212,212',// gray
+  '106,153,85', // green
+  '206,145,120',// salmon
+  '181,206,168',// light-green
+  '197,134,192',// purple
+  '111,19,19',  // maroon
+  '20,68,20',   // deep-green
+  '224,108,117',// pink
+  '156,220,254' // sky
 ];
 const COLORS = PALETTE_BASE.map(rgb => `rgba(${rgb},0.7)`);
 


### PR DESCRIPTION
## Summary
- switch asset classification and daily trend charts to new palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982141eae883288b9347258325c2d7